### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker build . --file Dockerfile --tag namelss:$(date +%s)
 
       - name: DockerHub Publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ikshitijsingh/namelss
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,7 +32,7 @@ jobs:
         run: docker build . --file Dockerfile --tag namelss:${{ env.RELEASE_VERSION }}
 
       - name: DockerHub Publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ikshitijsingh/namelss
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore